### PR TITLE
Moves marked from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kosui",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "type": "module",
   "license": "MIT",
   "packageManager": "pnpm@10.13.1",
@@ -58,7 +58,6 @@
     "eslint-plugin-svelte": "^3.0.0",
     "globals": "^16.0.0",
     "jsdom": "^26.1.0",
-    "marked": "^16.1.1",
     "postcss": "^8.5.6",
     "prettier": "^3.4.2",
     "prettier-plugin-svelte": "^3.3.3",
@@ -84,5 +83,8 @@
       "@tailwindcss/oxide",
       "esbuild"
     ]
+  },
+  "dependencies": {
+    "marked": "^16.1.1"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,10 @@ overrides:
 importers:
 
   .:
+    dependencies:
+      marked:
+        specifier: ^16.1.1
+        version: 16.1.1
     devDependencies:
       '@eslint/compat':
         specifier: ^1.2.5
@@ -62,9 +66,6 @@ importers:
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
-      marked:
-        specifier: ^16.1.1
-        version: 16.1.1
       postcss:
         specifier: ^8.5.6
         version: 8.5.6


### PR DESCRIPTION
Promotes the marked package from development dependencies to production dependencies, indicating it's now required at runtime rather than just for development builds.

Bumps version from 0.0.7 to 0.0.8 to reflect this dependency change.
